### PR TITLE
fixed a bug that occurred when scanning incomplete code

### DIFF
--- a/src/main/java/org/five/sonarqubot/events/FileServiceImpl.java
+++ b/src/main/java/org/five/sonarqubot/events/FileServiceImpl.java
@@ -67,7 +67,7 @@ public class FileServiceImpl implements FileService {
 
     private void writeToFile(String code, File file) {
         try (BufferedWriter bw = new BufferedWriter(new FileWriter(file.getAbsoluteFile()))) {
-            bw.write(code);
+            bw.write("public class ClassNameGeneratedBySonarQubot {\n" + code + "\n}"); //todo hardcoded for Java
         } catch (IOException e) {
             LOG.error("Sorry, there was a problem to write to the file");
             e.printStackTrace();


### PR DESCRIPTION
 If a method wasn't wrapped in a class then the scanner failed.
 
 Fixed this bug by automatically wrapping the input in a class